### PR TITLE
magstatics build for ARM architectures (e.g. MacOS)

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -3,7 +3,7 @@
 The Fortran code is compiled and wrapped to a module that can be directly called from Python.
 The tool `f2py` of the NumPy package is used to wrap the interface file `MagTense/python/magtense/lib/FortranToPythonIO.f90`.
 
-## Deployment with Conda
+## Deployment with Conda (Intel architectures)
 
 ### Requirements
 
@@ -25,7 +25,7 @@ The tool `f2py` of the NumPy package is used to wrap the interface file `MagTens
   HINT: Use `nvcc --version` or `nvidia-smi` to detect the correct CUDA version for your system.
 
   ```bash
-  conda install -y numpy matplotlib mkl 
+  conda install -y numpy matplotlib mkl
   conda install -y -c "nvidia/label/cuda-${CUDA_LABEL}" cuda-nvcc libcusparse-dev libcublas-dev cuda-cudart-dev
   conda install -y -c intel mkl-include mkl-static
   ```
@@ -48,7 +48,7 @@ The tool `f2py` of the NumPy package is used to wrap the interface file `MagTens
     conda install -y h5py tqdm
     ```
 
-### Installation from source
+### Installation from source (including MacOS Intel & ARM)
 
 Create an importable Python module from Fortran source code.
 
@@ -57,6 +57,15 @@ Navigate to folder `MagTense/python/magtense/lib/`, run `make`, and install the 
 ```bash
 cd MagTense/python/magtense/lib/
 make SHELL=cmd
+cd MagTense/python/
+pip install -e .
+```
+
+For MACos ARM architetures, use the associated Makefile. Currently this supports only magnetostatics.
+
+```bash
+cd MagTense/python/magtense/lib/
+make -f Makefile.arm64
 cd MagTense/python/
 pip install -e .
 ```
@@ -99,7 +108,7 @@ Libraries have to be pre-build for now, and should be located in `MagTense/pytho
 
 ```bash
 # Required conda packages for distribution
-conda install -y twine anaconda-client conda-build 
+conda install -y twine anaconda-client conda-build
 
 cd MagTense/python/
 

--- a/python/magtense/lib/FortranToPythonIOArm64.f90
+++ b/python/magtense/lib/FortranToPythonIOArm64.f90
@@ -1,0 +1,491 @@
+module FortranToPythonIOArm64
+
+    use DemagFieldGetSolution
+    use IterateMagnetSolution
+    implicit none
+
+    contains
+
+    !--------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    !> function for displaying output (to the terminal)
+    !! @param err the current relative error
+    !! @param err_max the current maximum allowed error
+    !!
+    function dispIte_fct( err, err_max )
+        real(8),intent(in) :: err,err_max
+        integer(4) :: dispIte_fct
+
+        write(*,*) err,err_max
+
+        dispIte_fct = 0
+
+    end function dispIte_fct
+
+    function dispIte_fct_no_output( err, err_max )
+        real(8),intent(in) :: err,err_max
+        integer(4) :: dispIte_fct_no_output
+
+        dispIte_fct_no_output = 0
+
+    end function dispIte_fct_no_output
+
+
+    !--------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    !< Function getNFromTiles
+    !! @param tileType - defines whether the tile is cylindrical, a prism, an ellipsoid and so on
+    !! @param offset - the centre coordinates relative to the global coordinate system
+    !! @param rotAngles - rotation angles (phi_x, phi_y, phi_z) about the principle axes of the tile with respect to the centre of the tile
+    !! @param color - color rgb triplet
+    !! @param magnetType - defines whether the tile is a hard or soft magnet
+    !! @param stateFunctionIndex - index matching an entry into an array of type MagStateFunction. Used by soft ferromagnets (when interpolation on an M vs H curve is necessary)
+    !! @param symmetryOps - 1 for symmetry, -1 for anti-symmetry ((1) for about xy plane, (2) for about (xz) plane and (3) for about yz plane)
+    !! @param Mrel - the current relative change of the magnetization (i.e. abs((M1-M2)/M2 ) where M1 is the latest magnetization norm and M2 is the previous one
+    !!
+    subroutine getNFromTiles( centerPos, dev_center, tile_size, vertices, Mag, u_ea, u_oa1, u_oa2, &
+        mu_r_ea, mu_r_oa, Mrem, tileType, offset, rotAngles, color, magnetType, stateFunctionIndex, &
+        includeInIteration, exploitSymmetry, symmetryOps, Mrel, pts, n_tiles, n_pts, N )
+        !::Specific for a cylindrical tile piece
+        real(8),dimension(n_tiles,3),intent(in) :: centerPos
+        real(8),dimension(n_tiles,3),intent(in) :: dev_center
+
+        !::Specific for a rectangular prism
+        real(8),dimension(n_tiles,3),intent(in) :: tile_size
+
+        !::Specific for a tetrahedron
+        real(8),dimension(n_tiles,3,4),intent(in) :: vertices
+
+        !::Generel variables, shared among all tile types
+        real(8),dimension(n_tiles,3),intent(in) :: Mag
+        real(8),dimension(n_tiles,3),intent(in) :: u_ea,u_oa1,u_oa2
+        real(8),dimension(n_tiles),intent(in) :: mu_r_ea,mu_r_oa,Mrem
+        integer(4),dimension(n_tiles),intent(in) :: tileType
+        real(8),dimension(n_tiles,3),intent(in) :: offset
+        real(8),dimension(n_tiles,3),intent(in) :: rotAngles
+        real(8),dimension(n_tiles,3),intent(in) :: color
+        integer(4),dimension(n_tiles),intent(in) :: magnetType
+        integer(4),dimension(n_tiles),intent(in) :: stateFunctionIndex
+        integer(4),dimension(n_tiles),intent(in) :: includeInIteration,exploitSymmetry
+        real(8),dimension(n_tiles,3),intent(in) :: symmetryOps
+        real(8),dimension(n_tiles),intent(in) :: Mrel
+
+        real(8),dimension(n_pts,3),intent(in) :: pts
+        real(8),dimension(n_pts,3) :: H
+        real(8),dimension(n_tiles,n_pts,3,3),intent(out) :: N
+        type(MagTile),dimension(n_tiles) :: tiles
+        integer(4),intent(in) :: n_tiles
+        integer(4),intent(in) :: n_pts
+        integer :: i
+
+        !::initialise MagTile with specified parameters
+        call loadTiles( centerPos, dev_center, tile_size, vertices, Mag, u_ea, u_oa1, u_oa2, &
+            mu_r_ea, mu_r_oa, Mrem, tileType, offset, rotAngles, color, magnetType, stateFunctionIndex, &
+            includeInIteration, exploitSymmetry, symmetryOps, Mrel, n_tiles, tiles )
+
+        !::do the calculation
+        N(:,:,:,:) = 0
+        H(:,:) = 0
+        ! $OMP PARALLEL DO PRIVATE(i)
+        do i=1,n_tiles
+            select case ( tiles(i)%tileType )
+            case ( tileTypeCylPiece )
+                call getFieldFromCylTile( tiles(i), H, pts, n_pts, N(i,:,:,:), .false. )
+            case ( tileTypePrism )
+                call getFieldFromRectangularPrismTile( tiles(i), H, pts, n_pts, N(i,:,:,:), .false. )
+            case ( tileTypeSphere )
+                call getFieldFromSphereTile( tiles(i), H, pts, n_pts, N(i,:,:,:), .false. )
+            case ( tileTypeSpheroid )
+                call getFieldFromSpheroidTile( tiles(i), H, pts, n_pts, N(i,:,:,:), .false. )
+            case ( tileTypeCircPiece )
+                call getFieldFromCircPieceTile( tiles(i), H, pts, n_pts, N(i,:,:,:), .false. )
+            case ( tileTypeCircPieceInverted )
+                call getFieldFromCircPieceInvertedTile( tiles(i), H, pts, n_pts, N(i,:,:,:), .false. )
+            case ( tileTypeTetrahedron )
+                call getFieldFromTetrahedronTile( tiles(i), H, pts, n_pts, N(i,:,:,:), .false. )
+            case (tileTypePlanarCoil )
+                call getFieldFromPlanarCoilTile( tiles(i), H, pts, n_pts, N(i,:,:,:), .false. )
+            case default
+            end select
+        enddo
+        ! $OMP END PARALLEL DO
+
+    end subroutine getNFromTiles
+
+    !--------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    !< Function getHFromTiles
+    !! @param tileType - defines whether the tile is cylindrical, a prism, an ellipsoid and so on
+    !! @param offset - the centre coordinates relative to the global coordinate system
+    !! @param rotAngles - rotation angles (phi_x, phi_y, phi_z) about the principle axes of the tile with respect to the centre of the tile
+    !! @param color - color rgb triplet
+    !! @param magnetType - defines whether the tile is a hard or soft magnet
+    !! @param stateFunctionIndex - index matching an entry into an array of type MagStateFunction. Used by soft ferromagnets (when interpolation on an M vs H curve is necessary)
+    !! @param symmetryOps - 1 for symmetry, -1 for anti-symmetry ((1) for about xy plane, (2) for about (xz) plane and (3) for about yz plane)
+    !! @param Mrel - the current relative change of the magnetization (i.e. abs((M1-M2)/M2 ) where M1 is the latest magnetization norm and M2 is the previous one
+    !!
+    subroutine getHFromTiles( centerPos, dev_center, tile_size, vertices, Mag, u_ea, u_oa1, u_oa2, &
+        mu_r_ea, mu_r_oa, Mrem, tileType, offset, rotAngles, color, magnetType, stateFunctionIndex, &
+        includeInIteration, exploitSymmetry, symmetryOps, Mrel, pts, n_tiles, n_pts, H, N, useStoredN )
+
+        !::Specific for a cylindrical tile piece
+        real(8),dimension(n_tiles,3),intent(in) :: centerPos
+        real(8),dimension(n_tiles,3),intent(in) :: dev_center
+
+        !::Specific for a rectangular prism
+        real(8),dimension(n_tiles,3),intent(in) :: tile_size
+
+        !::Specific for a tetrahedron
+        real(8),dimension(n_tiles,3,4),intent(in) :: vertices
+
+        !::Generel variables, shared among all tile types
+        real(8),dimension(n_tiles,3),intent(in) :: Mag
+        real(8),dimension(n_tiles,3),intent(in) :: u_ea,u_oa1,u_oa2
+        real(8),dimension(n_tiles),intent(in) :: mu_r_ea,mu_r_oa,Mrem
+        integer(4),dimension(n_tiles),intent(in) :: tileType
+        real(8),dimension(n_tiles,3),intent(in) :: offset
+        real(8),dimension(n_tiles,3),intent(in) :: rotAngles
+        real(8),dimension(n_tiles,3),intent(in) :: color
+        integer(4),dimension(n_tiles),intent(in) :: magnetType
+        integer(4),dimension(n_tiles),intent(in) :: stateFunctionIndex
+        integer(4),dimension(n_tiles),intent(in) :: includeInIteration,exploitSymmetry
+        real(8),dimension(n_tiles,3),intent(in) :: symmetryOps
+        real(8),dimension(n_tiles),intent(in) :: Mrel
+
+        real(8),dimension(n_pts,3),intent(in) :: pts
+        real(8),dimension(n_pts,3),intent(out) :: H
+        real(8),dimension(n_pts,3) :: H_tmp
+        real(8),dimension(n_tiles,n_pts,3,3),intent(in) :: N
+        real(8),dimension(n_tiles,n_pts,3,3) :: N_out
+        logical,intent(in) :: useStoredN
+
+        type(MagTile),dimension(n_tiles) :: tiles
+        integer(4),intent(in) :: n_tiles
+        integer(4),intent(in) :: n_pts
+        integer :: i
+
+        !::initialise MagTile with specified parameters
+        call loadTiles( centerPos, dev_center, tile_size, vertices, Mag, u_ea, u_oa1, u_oa2, &
+            mu_r_ea, mu_r_oa, Mrem, tileType, offset, rotAngles, color, magnetType, stateFunctionIndex, &
+            includeInIteration, exploitSymmetry, symmetryOps, Mrel, n_tiles, tiles )
+
+        N_out = N
+        H(:,:) = 0.
+
+        ! $OMP PARALLEL DO PRIVATE(i,H_tmp)
+        do i=1,n_tiles
+
+            !Make sure to allocate H_tmp on the heap and for each thread
+            ! $OMP CRITICAL
+            H_tmp(:,:) = 0.
+
+            ! $OMP END CRITICAL
+            !! Here a selection of which subroutine to use should be done, i.e. whether the tile
+            !! is cylindrical, a prism or an ellipsoid or another geometry
+            select case ( tiles(i)%tileType )
+            case ( tileTypeCylPiece )
+                if ( useStoredN .eqv. .true. ) then
+                    call getFieldFromCylTile( tiles(i), H_tmp, pts, n_pts, N_out(i,:,:,:), useStoredN )
+                else
+                    call getFieldFromCylTile( tiles(i), H_tmp, pts, n_pts )
+                endif
+            case ( tileTypePrism )
+                if ( useStoredN .eqv. .true. ) then
+                    call getFieldFromRectangularPrismTile( tiles(i), H_tmp, pts, n_pts, N_out(i,:,:,:), useStoredN )
+                else
+                    call getFieldFromRectangularPrismTile( tiles(i), H_tmp, pts, n_pts )
+                endif
+            case ( tileTypeSphere )
+                if ( useStoredN .eqv. .true. ) then
+                    call getFieldFromSphereTile( tiles(i), H_tmp, pts, n_pts, N_out(i,:,:,:), useStoredN )
+                else
+                    call getFieldFromSphereTile( tiles(i), H_tmp, pts, n_pts )
+                endif
+            case ( tileTypeSpheroid )
+                if ( useStoredN .eqv. .true. ) then
+                    call getFieldFromSpheroidTile( tiles(i), H_tmp, pts, n_pts, N_out(i,:,:,:), useStoredN )
+                else
+                    call getFieldFromSpheroidTile( tiles(i), H_tmp, pts, n_pts )
+                endif
+            case ( tileTypeCircPiece )
+                if ( useStoredN .eqv. .true. ) then
+                    call getFieldFromCircPieceTile( tiles(i), H_tmp, pts, n_pts, N_out(i,:,:,:), useStoredN )
+                else
+                    call getFieldFromCircPieceTile( tiles(i), H_tmp, pts, n_pts )
+                endif
+            case ( tileTypeCircPieceInverted )
+                if ( useStoredN .eqv. .true. ) then
+                    call getFieldFromCircPieceInvertedTile( tiles(i), H_tmp, pts, n_pts, N_out(i,:,:,:), useStoredN )
+                else
+                    call getFieldFromCircPieceInvertedTile( tiles(i), H_tmp, pts, n_pts )
+                endif
+            case ( tileTypeTetrahedron )
+                if ( useStoredN .eqv. .true. ) then
+                    call getFieldFromTetrahedronTile( tiles(i), H_tmp, pts, n_pts, N_out(i,:,:,:), useStoredN )
+                else
+                    call getFieldFromTetrahedronTile( tiles(i), H_tmp, pts, n_pts )
+                endif
+            case ( tileTypePlanarCoil )
+                if ( useStoredN .eqv. .true. ) then
+                    call getFieldFromPlanarCoilTile( tiles(i), H_tmp, pts, n_pts, N_out(i,:,:,:), useStoredN )
+                else
+                    call getFieldFromPlanarCoilTile( tiles(i), H_tmp, pts, n_pts )
+                endif
+
+            case default
+
+            end select
+
+            H = H + H_tmp
+
+        enddo
+        ! $OMP END PARALLEL DO
+
+        call SubtractMFromCylindricalTiles( H, tiles, pts, n_tiles, n_pts )
+
+    end subroutine getHFromTiles
+
+    !--------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    !< Function IterateTiles
+    !! @param tileType - defines whether the tile is cylindrical, a prism, an ellipsoid and so on
+    !! @param offset - the centre coordinates relative to the global coordinate system
+    !! @param rotAngles - rotation angles (phi_x, phi_y, phi_z) about the principle axes of the tile with respect to the centre of the tile
+    !! @param color - color rgb triplet
+    !! @param magnetType - defines whether the tile is a hard or soft magnet
+    !! @param stateFunctionIndex - index matching an entry into an array of type MagStateFunction. Used by soft ferromagnets (when interpolation on an M vs H curve is necessary)
+    !! @param symmetryOps - 1 for symmetry, -1 for anti-symmetry ((1) for about xy plane, (2) for about (xz) plane and (3) for about yz plane)
+    !! @param Mrel - the current relative change of the magnetization (i.e. abs((M1-M2)/M2 ) where M1 is the latest magnetization norm and M2 is the previous one
+    !!
+    subroutine IterateTiles( centerPos, dev_center, tile_size, vertices, Mag, u_ea, u_oa1, u_oa2, &
+        mu_r_ea, mu_r_oa, Mrem, tileType, offset, rotAngles, color, magnetType, stateFunctionIndex, &
+        includeInIteration, exploitSymmetry, symmetryOps, Mrel, n_tiles, nT, nH, n_stateFcn, &
+        data_stateFcn, T, maxErr, nIteMax, Mag_out, Mrel_out )
+
+        !::Specific for a cylindrical tile piece
+        real(8),dimension(n_tiles,3),intent(in) :: centerPos
+        real(8),dimension(n_tiles,3),intent(in) :: dev_center
+
+        !::Specific for a rectangular prism
+        real(8),dimension(n_tiles,3),intent(in) :: tile_size
+
+        !::Specific for a tetrahedron
+        real(8),dimension(n_tiles,3,4),intent(in) :: vertices
+
+        !::Generel variables, shared among all tile types
+        real(8),dimension(n_tiles,3),intent(in) :: Mag
+        real(8),dimension(n_tiles,3),intent(out) :: Mag_out
+        real(8),dimension(n_tiles,3),intent(in) :: u_ea,u_oa1,u_oa2
+        real(8),dimension(n_tiles),intent(in) :: mu_r_ea,mu_r_oa,Mrem
+        integer(4),dimension(n_tiles),intent(in) :: tileType
+        real(8),dimension(n_tiles,3),intent(in) :: offset
+        real(8),dimension(n_tiles,3),intent(in) :: rotAngles
+        real(8),dimension(n_tiles,3),intent(in) :: color
+        integer(4),dimension(n_tiles),intent(in) :: magnetType
+        integer(4),dimension(n_tiles),intent(in) :: stateFunctionIndex
+        integer(4),dimension(n_tiles),intent(in) :: includeInIteration,exploitSymmetry
+        real(8),dimension(n_tiles,3),intent(in) :: symmetryOps
+        real(8),dimension(n_tiles),intent(in) :: Mrel
+        real(8),dimension(n_tiles),intent(out) :: Mrel_out
+
+        real(8),intent(in) :: maxErr, T
+        integer(4) :: nIteMax
+        type(MagStateFunction),dimension(n_stateFcn) :: stateFcn
+        integer(4),intent(in) :: n_stateFcn
+        integer(4),intent(in) :: nT,nH
+        real(8),dimension(nH,nT),intent(in) :: data_stateFcn
+        real(8) :: resumeIteration
+        procedure(displayIteration_fct),pointer :: disp_fct => null()
+
+        type(MagTile),dimension(n_tiles) :: tiles
+        integer(4),intent(in) :: n_tiles
+        integer :: i
+
+        !! default value is zero, i.e. do not resume iteration
+        resumeIteration = 0.
+
+        disp_fct => dispIte_fct_no_output
+
+        !::initialise MagTile with specified parameters
+        call loadTiles( centerPos, dev_center, tile_size, vertices, Mag, u_ea, u_oa1, u_oa2, &
+            mu_r_ea, mu_r_oa, Mrem, tileType, offset, rotAngles, color, magnetType, stateFunctionIndex, &
+            includeInIteration, exploitSymmetry, symmetryOps, Mrel, n_tiles, tiles )
+
+        !::load state function from table
+        call loadStateFunction( nT, nH, stateFcn, data_stateFcn, n_stateFcn)
+        call iterateMagnetization( tiles, n_tiles, stateFcn, n_stateFcn, T, maxErr, nIteMax, disp_fct, resumeIteration )
+
+        do i=1,n_tiles
+            Mag_out(i,:) = tiles(i)%M
+            Mrel_out(i) = tiles(i)%Mrel
+        enddo
+
+    end subroutine IterateTiles
+
+    !--------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    !< Function runSimulation
+    !! @param tileType - defines whether the tile is cylindrical, a prism, an ellipsoid and so on
+    !! @param offset - the centre coordinates relative to the global coordinate system
+    !! @param rotAngles - rotation angles (phi_x, phi_y, phi_z) about the principle axes of the tile with respect to the centre of the tile
+    !! @param color - color rgb triplet
+    !! @param magnetType - defines whether the tile is a hard or soft magnet
+    !! @param stateFunctionIndex - index matching an entry into an array of type MagStateFunction. Used by soft ferromagnets (when interpolation on an M vs H curve is necessary)
+    !! @param symmetryOps - 1 for symmetry, -1 for anti-symmetry ((1) for about xy plane, (2) for about (xz) plane and (3) for about yz plane)
+    !! @param Mrel - the current relative change of the magnetization (i.e. abs((M1-M2)/M2 ) where M1 is the latest magnetization norm and M2 is the previous one
+    !!
+    subroutine runSimulation( centerPos, dev_center, tile_size, vertices, Mag, u_ea, u_oa1, u_oa2, &
+        mu_r_ea, mu_r_oa, Mrem, tileType, offset, rotAngles, color, magnetType, stateFunctionIndex, &
+        includeInIteration, exploitSymmetry, symmetryOps, Mrel, n_tiles, n_stateFcn, nT, nH, &
+        data_stateFcn, T, maxErr, nIteMax, iterateSolution, returnSolution, n_pts, pts, H, Mag_out, Mrel_out, console )
+
+        !::Specific for a cylindrical tile piece
+        real(8),dimension(n_tiles,3),intent(in) :: centerPos
+        real(8),dimension(n_tiles,3),intent(in) :: dev_center
+
+        !::Specific for a rectangular prism
+        real(8),dimension(n_tiles,3),intent(in) :: tile_size
+
+        !::Specific for a tetrahedron
+        real(8),dimension(n_tiles,3,4),intent(in) :: vertices
+
+        !::Generel variables, shared among all tile types
+        real(8),dimension(n_tiles,3),intent(in) :: Mag
+        real(8),dimension(n_tiles,3),intent(out) :: Mag_out
+        real(8),dimension(n_tiles,3),intent(in) :: u_ea,u_oa1,u_oa2
+        !! real(8),dimension(n_tiles,3),intent(out) :: u_ea_out,u_oa1_out,u_oa2_out
+        real(8),dimension(n_tiles),intent(in) :: mu_r_ea,mu_r_oa,Mrem
+        integer(4),dimension(n_tiles),intent(in) :: tileType
+        real(8),dimension(n_tiles,3),intent(in) :: offset
+        real(8),dimension(n_tiles,3),intent(in) :: rotAngles
+        real(8),dimension(n_tiles,3),intent(in) :: color
+        integer(4),dimension(n_tiles),intent(in) :: magnetType
+        integer(4),dimension(n_tiles),intent(in) :: stateFunctionIndex
+        integer(4),dimension(n_tiles),intent(in) :: includeInIteration,exploitSymmetry
+        real(8),dimension(n_tiles,3),intent(in) :: symmetryOps
+        real(8),dimension(n_tiles),intent(in) :: Mrel
+        real(8),dimension(n_tiles),intent(out) :: Mrel_out
+
+        real(8) :: maxErr, T
+        integer(4) :: nIteMax
+        logical,intent(in) :: iterateSolution, returnSolution
+        type(MagStateFunction),dimension(n_stateFcn) :: stateFcn
+        integer(4),intent(in) :: n_stateFcn !! Currently just one state function supported, can be extendend to input variable
+        integer(4),intent(in):: nT,nH
+        real(8),dimension(nH,nT),intent(in) :: data_stateFcn
+        real(8) :: start,finish,resumeIteration
+        procedure(displayIteration_fct),pointer :: disp_fct => null()
+        logical, intent(in) :: console
+
+        real(8),dimension(n_pts,3),intent(in) :: pts
+        real(8),dimension(n_pts,3),intent(out) :: H
+        real(8),dimension(n_pts,3) :: H_tmp
+        type(MagTile),dimension(n_tiles) :: tiles
+        integer(4),intent(in) :: n_tiles
+        integer(4),intent(in) :: n_pts
+        integer :: i
+
+        call cpu_time(start)
+
+        if (console) then
+            disp_fct => dispIte_fct
+        else
+            disp_fct => dispIte_fct_no_output
+        endif
+
+        !!@todo no support for resuming iterations at the moment
+        resumeIteration = 0
+
+        !::initialise MagTile with specified parameters
+        call loadTiles( centerPos, dev_center, tile_size, vertices, Mag, u_ea, u_oa1, u_oa2, &
+            mu_r_ea, mu_r_oa, Mrem, tileType, offset, rotAngles, color, magnetType, stateFunctionIndex, &
+            includeInIteration, exploitSymmetry, symmetryOps, Mrel, n_tiles, tiles )
+
+        !::load state function from table
+        call loadStateFunction( nT, nH, stateFcn, data_stateFcn, n_stateFcn )
+
+        if ( iterateSolution .eqv. .true. ) then
+            if (console) then
+                write(*,*) 'Doing iteration'
+            endif
+            call iterateMagnetization( tiles, n_tiles, stateFcn, n_stateFcn, T, maxErr, nIteMax, disp_fct, resumeIteration )
+
+            do i=1,n_tiles
+                ! centerPos(i,1) = tiles(i)%r0
+                ! centerPos(i,2) = tiles(i)%theta0
+                ! centerPos(i,3) = tiles(i)%z0
+                ! dev_center(i,1) = tiles(i)%dr
+                ! dev_center(i,2) = tiles(i)%dtheta
+                ! dev_center(i,3) = tiles(i)%dz
+                ! tile_size(i,1) = tiles(i)%a
+                ! tile_size(i,2) = tiles(i)%b
+                ! tile_size(i,3) = tiles(i)%c
+                Mag_out(i,:) = tiles(i)%M
+                ! u_ea_out(i,:) = tiles(i)%u_ea
+                ! u_oa1_out(i,:) = tiles(i)%u_oa1
+                ! u_oa2_out(i,:) = tiles(i)%u_oa2
+                ! mu_r_ea(i) = tiles(i)%mu_r_ea
+                ! mu_r_oa(i) = tiles(i)%mu_r_oa
+                ! Mrem(i) = tiles(i)%Mrem
+                ! tileType(i) = tiles(i)%tileType
+                ! offset(i,:) = tiles(i)%offset
+                ! rotAngles(i,:) = tiles(i)%rotAngles
+                ! color(i,:) = tiles(i)%color
+                ! magnetType(i) = tiles(i)%magnetType
+                ! stateFunctionIndex(i) = tiles(i)%stateFunctionIndex
+                ! includeInIteration(i) = tiles(i)%includeInIteration
+                ! exploitSymmetry(i) = tiles(i)%exploitSymmetry
+                ! symmetryOps(i,:) = tiles(i)%symmetryOps
+                Mrel_out(i) = tiles(i)%Mrel
+            enddo
+        endif
+
+        if ( returnSolution .eqv. .true. ) then
+            if (console) then
+                write(*,*) 'Finding solution at requested points'
+            endif
+
+            H(:,:) = 0.
+
+            ! $OMP PARALLEL DO PRIVATE(i,H_tmp)
+            do i=1,n_tiles
+
+                !Make sure to allocate H_tmp on the heap and for each thread
+                ! $OMP CRITICAL
+                H_tmp(:,:) = 0.
+
+                ! $OMP END CRITICAL
+                !! Here a selection of which subroutine to use should be done, i.e. whether the tile
+                !! is cylindrical, a prism or an ellipsoid or another geometry
+                select case (tiles(i)%tileType )
+                case (tileTypeCylPiece)
+                    call getFieldFromCylTile( tiles(i), H_tmp, pts, n_pts )
+                case (tileTypePrism)
+                    call getFieldFromRectangularPrismTile( tiles(i), H_tmp, pts, n_pts )
+                case (tileTypeSphere)
+                    call getFieldFromSphereTile( tiles(i), H_tmp, pts, n_pts )
+                case (tileTypeSpheroid)
+                    call getFieldFromSpheroidTile( tiles(i), H_tmp, pts, n_pts )
+                case (tileTypeCircPiece )
+                    call getFieldFromCircPieceTile( tiles(i), H_tmp, pts, n_pts )
+                case (tileTypeCircPieceInverted )
+                    call getFieldFromCircPieceInvertedTile( tiles(i), H_tmp, pts, n_pts )
+                case (tileTypeTetrahedron )
+                    call getFieldFromTetrahedronTile( tiles(i), H_tmp, pts, n_pts )
+                case (tileTypePlanarCoil )
+                    call getFieldFromPlanarCoilTile( tiles(i), H_tmp, pts, n_pts )
+                case default
+                end select
+
+                H = H + H_tmp
+
+            enddo
+            ! $OMP END PARALLEL DO
+
+            call SubtractMFromCylindricalTiles( H, tiles, pts, n_tiles, n_pts )
+        endif
+
+        call cpu_time(finish)
+
+        if (console) then
+            write(*,*) 'Elapsed time', finish-start
+        endif
+
+    end subroutine runSimulation
+
+end module FortranToPythonIOArm64

--- a/python/magtense/lib/Makefile.arm64
+++ b/python/magtense/lib/Makefile.arm64
@@ -1,0 +1,68 @@
+#=======================================================================
+#                   define the compiler names
+#=======================================================================
+F90 = gfortran
+
+#=======================================================================
+#                     additional flags
+#=======================================================================
+F90FLAGS = -fPIC -O3 -fopenmp -fdefault-real-8 -ffree-line-length-512
+FCOMP = gnu95
+
+VPATH = ../../../source/NumericalIntegration/NumericalIntegration:\
+../../../source/TileDemagTensor/TileDemagTensor:\
+../../../source/DemagField/DemagField
+FPP = gfortran -E # gfortran f90wrap temp files only, not compilation
+FPP_F90FLAGS = -x f95-cpp-input -fPIC
+CC = gcc
+CFLAGS = -fPIC
+
+LIBTOOL = libtool -static -o
+CLEAN_FILES = -rm libsrc.a *.o *.mod *.so
+CLEAN_FOLDER = -rm -r src.*
+CLEAN_FOLDER_WIN = -true
+
+# ======================================================================
+# PROJECT CONFIG, do not put spaced behind the variables
+# ======================================================================
+# Python module name
+PYTHON_MODN = magtensesource
+#=======================================================================
+#       List all source files required for the project
+#=======================================================================
+# names (without suffix), f90 sources
+LIBSRC_SOURCES = IntegrationDataTypes quadpack SpecialFunctions TileTensorHelperFunctions \
+TileRectangularPrismTensor TileCircPieceTensor TileCylPieceTensor TilePlanarCoilTensor TileTriangle\
+TileNComponents DemagFieldGetSolution spline MagParameters IterateMagnetSolution
+# file names
+LIBSRC_FILES = $(addsuffix .f90,${LIBSRC_SOURCES})
+# object files
+LIBSRC_OBJECTS = $(addsuffix .o,${LIBSRC_SOURCES})
+#=======================================================================
+#       List all source files that require a Python interface
+#=======================================================================
+# names (without suffix), f90 sources
+LIBSRC_WRAP_SOURCES = FortranToPythonIOArm64
+# file names
+LIBSRC_WRAP_FILES = $(addsuffix .f90,${LIBSRC_WRAP_SOURCES})
+#=======================================================================
+#                 Relevant suffixes
+#=======================================================================
+.SUFFIXES: .f90
+#=======================================================================
+#
+#=======================================================================
+.PHONY: all clean
+all: _${PYTHON_MODN}.so
+clean:
+	${CLEAN_FILES}
+	${CLEAN_FOLDER}
+	${CLEAN_FOLDER_WIN}
+.f90.o:
+	${F90} ${F90FLAGS} -c $< -o $@
+.c.o:
+	${CC} ${CFLAGS} -c $< -o $@
+libsrc.a: ${LIBSRC_OBJECTS}
+	${LIBTOOL} $@ $?
+_${PYTHON_MODN}.so: libsrc.a
+	f2py --build-dir . --fcompiler=${FCOMP} --opt='${F90FLAGS}' -c -m ${PYTHON_MODN} -L. -lsrc ${LIBSRC_WRAP_FILES} ${LIBSRC_OBJECTS}


### PR DESCRIPTION
This PR (re-?)adds the ability to build and use MagTense on ARM architectures (i.e. any current or future MacOS). Presently only the magstatics module can be used. We can discuss whether it's appropriate to actually merge this now.

To develop a ARM build consistent with Windows / Linux, we need to:
- Identify a replacement for Intel MKL library interfaces for the micromagnetics module. The underlying libraries (BLAS etc.) are already present on MacOS through Apple's Accelerate.framework. Open question: in principle we can change the interfaces used in the f90 L-L code to a non-proprietary interface, but in practice we may need separate Fortran code.
- Similarly, this is implemented by simply adding a separate Makefile & IO module f90 file. Better if we can have a unified Makefile.