### PR TITLE
sampling perf improvement and sneaky bugfix

### DIFF
--- a/python/magtense/magstatics.py
+++ b/python/magtense/magstatics.py
@@ -709,21 +709,20 @@ def grid_config(
         raise NotImplementedError()
 
     if filled_pos is None:
-        filled_pos = []
         if n_tiles is None:
-            n_tiles = rng.integers(np.prod(spots))
+            n_tiles = 1 + rng.integers(np.prod(spots))
 
-        cnt_tiles = 0
-        while cnt_tiles < n_tiles:
-            new_pos = [
-                rng.integers(spots[0]),
-                rng.integers(spots[1]),
-                rng.integers(spots[2]),
-            ]
+        # Generate unique linear indices
+        linear_indices = rng.choice(np.prod(spots), size=n_tiles, replace=False)
 
-            if new_pos not in filled_pos:
-                filled_pos.append(new_pos)
-                cnt_tiles += 1
+        # Convert the linear indices to 3D coordinates
+        filled_pos = np.empty((n_tiles, 3), dtype=int)
+        for idx, linear_index in enumerate(linear_indices):
+            filled_pos[idx, 2] = linear_index // (spots[0] * spots[1])
+            filled_pos[idx, 1] = (linear_index % (spots[0] * spots[1])) // spots[0]
+            filled_pos[idx, 0] = linear_index % spots[0]
+        filled_pos = filled_pos.tolist()
+
 
     if len(filled_pos) == 0:
         tiles = None


### PR DESCRIPTION
If one is generating many random configurations, it's desirable not to use rejection sampling, and instead use numpy inbuilt `choice` to sample without replacement.

Also the random choice for the number of tiles should be guaranteed not to return zero, which will result in tiles being `None`. Adding `1 + ` ensures the number of tiles is between 1 and the total number of spots (inclusive at both ends).

e.g. as used in [this random prism tiling generator](https://github.com/cmt-dtu-energy/magstatics-learning/blob/3a26553429443e9e3114f8b288cfa7002ad16ff0/src/magstatics_learning/configurations.py)