### PR TITLE
Fix Windows self-hosted Python resolution in FMM wheel workflow

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -243,36 +243,25 @@ jobs:
         name: pip-wheel-py${{ matrix.py-version.name }}-cu12-fmm-${{ runner.os }}
 
     - name: Setup python
-      if: ${{ matrix.fmm_runner.os_name == 'linux' }}
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.py-version.id }}
+        check-latest: true
 
-    - name: Resolve Windows Python
+    - name: Python diagnostics (Linux/macOS)
+      if: ${{ matrix.fmm_runner.os_name != 'windows' }}
+      run: |
+        python --version
+        which python
+        python -c "import sys; print('selected:', sys.executable)"
+
+    - name: Python diagnostics (Windows)
       if: ${{ matrix.fmm_runner.os_name == 'windows' }}
       shell: cmd
       run: |
-        set "PYTHON_EXE="
-        for /f "delims=" %%p in ('where python 2^>nul') do (
-          if not defined PYTHON_EXE set "PYTHON_EXE=%%p"
-        )
-        if not defined PYTHON_EXE (
-          for /d %%d in ("%RUNNER_TOOL_CACHE%\Python\${{ matrix.py-version.id }}.*\x64") do (
-            if exist "%%d\python.exe" set "PYTHON_EXE=%%d\python.exe"
-          )
-        )
-        if not defined PYTHON_EXE (
-          for /d %%d in ("%AGENT_TOOLSDIRECTORY%\Python\${{ matrix.py-version.id }}.*\x64") do (
-            if exist "%%d\python.exe" set "PYTHON_EXE=%%d\python.exe"
-          )
-        )
-        if not defined PYTHON_EXE (
-          echo Could not find Python ${{ matrix.py-version.id }} on this self-hosted Windows runner.
-          echo Install Python ${{ matrix.py-version.id }} and add it to PATH, or pre-populate the Actions toolcache.
-          exit /b 1
-        )
-        "%PYTHON_EXE%" -c "import sys; expected=tuple(map(int, '${{ matrix.py-version.id }}'.split('.'))); print(sys.executable); print(sys.version); raise SystemExit(0 if sys.version_info[:2] == expected else f'Expected Python {expected}, got {sys.version_info[:2]}')"
-        echo PYTHON_EXE=%PYTHON_EXE%>> "%GITHUB_ENV%"
+        python --version
+        where python
+        python -c "import sys; print('selected:', sys.executable)"
 
     - name: Show CUDA device info
       if: ${{ matrix.fmm_runner.os_name == 'linux' }}
@@ -284,7 +273,7 @@ jobs:
       if: ${{ matrix.fmm_runner.os_name == 'windows' }}
       shell: cmd
       run: |
-        "%PYTHON_EXE%" -c "import shutil; print('nvidia-smi:', shutil.which('nvidia-smi'))"
+        python -c "import shutil; print('nvidia-smi:', shutil.which('nvidia-smi'))"
         nvidia-smi
 
     - name: Install pip-wheel and pytest
@@ -304,9 +293,9 @@ jobs:
         MAGTENSE_USE_FMM3D: 1
         MAGTENSE_WHEEL_VARIANT: cu12-fmm
       run: |
-        for %%f in ("%GITHUB_WORKSPACE%\*.whl") do "%PYTHON_EXE%" -m pip install "%%f"
-        "%PYTHON_EXE%" -m pip install pytest
-        "%PYTHON_EXE%" -m pytest python/tests/fmm_test/test_fmm_workflow.py
+        for %%f in ("%GITHUB_WORKSPACE%\*.whl") do python -m pip install "%%f"
+        python -m pip install pytest
+        python -m pytest python/tests/fmm_test/test_fmm_workflow.py
 
         
   cache-conda-win:


### PR DESCRIPTION
### Motivation
- The Windows self-hosted runner failed locating Python 3.13 using fragile, hard-coded probes (`where python` + toolcache paths), so provisioning needs to be more robust.
- Prefer using `actions/setup-python` so the workflow can download or select the requested interpreter instead of relying on preinstalled toolcache entries.
- Keep the existing matrix intent (Python 3.12 and 3.13) and make Windows/Linux/macOS paths and diagnostics consistent for easier debugging.

### Description
- Replace the manual `Resolve Windows Python` cmd probe with `actions/setup-python@v5` for all OS matrix entries and enable `check-latest: true` to allow setup to fetch the requested interpreter when not preinstalled.
- Add lightweight OS-specific Python diagnostics that print `python --version`, `which python` / `where python`, and the selected executable to help diagnose runner configuration.
- Update Windows CUDA and test steps to call `python` from PATH (provided by `setup-python`) instead of using a custom `PYTHON_EXE` variable, and normalize the `nvidia-smi` diagnostic invocation to use `python` on Windows.
- Preserve the existing matrix entries for `3.12` and `3.13` and avoid hard-coded toolcache or agent paths.

### Testing
- No CI workflows were executed as part of this change; repository validation checks (diff and whitespace checks) completed successfully.
- The modified workflow file was parsed and validated in-place (no YAML syntax errors detected by local checks).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b08a48f0483268578452fc40a9300)