### PR TITLE
Add adaptive external-field hysteresis: Fortran backend, Python API and CLI

### DIFF
--- a/python/FortranToPythonIO.f90
+++ b/python/FortranToPythonIO.f90
@@ -789,6 +789,179 @@ end subroutine getHFromTilesFMM
 
     end subroutine RunMicroMagSimulation
 
+    subroutine RunMicroMagAdaptiveHysteresis( ntot, grid_n, grid_L, grid_type, u_ea, ProblemMode, solver, A0, Ms, K0, &
+        K1, K2, K0_arr, CrysAxis, gamma, alpha_mm, temperature, MaxT0, nt_Hext, n_Hext, nt_Hext_out, Hext, nt, t, m0, dem_thres, useCuda, dem_appr, N_ret, N_file_out, &
+        N_load, N_file_in, setTimeDis, nt_alpha, alphat, tol, thres, useCVODE, nt_conv, t_conv, &
+        conv_tol, grid_pts, grid_ele, grid_nod, grid_nnod, exch_nval, exch_nrow, exch_val, exch_rows, &
+        exch_cols, grid_abc, usePrecision, nThreadsMatlab, N_ave, CV, useReturnHall, useAvgN, demigstp, &
+		exch_weigh, exch_meth, exch_intpn, passExch, exch_ncols, exch_presize, &
+        n_macro, shiftVec, macroShape, sampleShape, exchPBC, &
+        H_start, H_end, dH_initial, dH_min, dH_max, maxHextSteps, dM_min, dM_target, dM_reject, dH_grow, dH_shrink, switch_refine_dH, use_switch_refine, &
+        t_out, M_mm, pts, H_exc, H_ext, H_dem, H_ani, n_Hext_accepted, &
+		n_tot_Exch, ExchMat_r, ExchMat_c, ExchMat_v, ExchMat_nr, ExchMat_nc, dummy_run, fmm_cells_per_node, eps_fmm, ifunif, nlmin, nlmax, allow_fmm_short_circuit, fmm_min_n, fmm_nterms, useFMM, &
+        log_dir,timer_log_file, trace_log_file, window_enabled, window_interval, trace_enabled, flush_each, trace_verbose, useDemag )
+
+        integer(4), intent(in) :: ntot, nt_conv, grid_type, nt_Hext, n_Hext, nt_alpha, nt, grid_nnod, exch_nval, exch_nrow, exch_ncols, exch_presize
+        integer(4), intent(in) :: nt_Hext_out
+        integer(4),dimension(3),intent(in) :: grid_n, N_ave
+        real(8),dimension(3),intent(in) :: grid_L
+        real(8),dimension(3),intent(in) :: H_start, H_end
+        real(8),intent(in) :: dH_initial, dH_min, dH_max, dM_min, dM_target, dM_reject, dH_grow, dH_shrink, switch_refine_dH
+        integer(4),intent(in) :: maxHextSteps, use_switch_refine
+        real(8),dimension(ntot,3),intent(in) :: grid_pts
+        integer(4),dimension(4,ntot),intent(in) :: grid_ele
+        real(8),dimension(grid_nnod,3),intent(in) :: grid_nod
+        real(8),dimension(ntot, 3),intent(in) :: grid_abc, u_ea
+        real(8),dimension(nt_Hext, 4),intent(in) :: Hext
+        real(8),dimension(3*ntot),intent(in) :: m0
+        real(8),dimension(nt_alpha,2),intent(in) :: alphat
+        integer(4),dimension(exch_nval),intent(in) :: exch_val, exch_cols, exch_rows
+        real(8),dimension(nt_conv),intent(in) :: t_conv
+		integer(4),intent(in) :: ProblemMode, solver, useCuda, dem_appr, usePrecision, nThreadsMatlab, useAvgN
+		integer(4),intent(in) :: N_ret, N_load, setTimeDis, useCVODE, useReturnHall, demigstp, exch_meth, exch_intpn, passExch, useDemag
+        real(8),intent(in) :: gamma, alpha_mm, MaxT0, tol, thres, conv_tol, dem_thres
+		real(8),dimension(ntot),intent(in) :: A0, Ms, K0, K1, K2, temperature
+        real(8),dimension(ntot,6,3),intent(in) :: K0_arr
+        real(8),dimension(ntot,3,3),intent(in):: CrysAxis
+        character*256,intent(in) :: N_file_in, N_file_out
+		real(8), intent(in) :: CV, exch_weigh
+
+        integer(4),dimension(3),intent(in) :: n_macro
+        real(8),dimension(3),intent(in) :: shiftVec, macroShape, sampleShape
+        integer(4),dimension(3),intent(in) :: exchPBC
+
+        real(8),dimension(nt),intent(in) :: t
+        real(8),dimension(nt),intent(out) :: t_out
+        real(8),dimension(nt,ntot,nt_Hext_out,3),intent(out) :: M_mm
+        real(8),dimension(nt,ntot,nt_Hext_out,3),intent(out) :: H_exc, H_ext, H_dem, H_ani
+        integer(4),intent(out) :: n_Hext_accepted
+        real(8),dimension(ntot,3),intent(out) :: pts
+
+		integer,intent(out) :: n_tot_Exch
+		integer,dimension(exch_presize*ntot),intent(out)  :: ExchMat_r
+		integer,dimension(exch_presize*ntot),intent(out)  :: ExchMat_c
+		real(8),dimension(exch_presize*ntot),intent(out)  :: ExchMat_v
+		integer,intent(out) :: ExchMat_nr,ExchMat_nc
+
+        integer, intent(in) :: dummy_run
+        integer(4), intent(in) :: fmm_cells_per_node
+        real(8), intent(in) :: eps_fmm
+        integer(4), intent(in) :: ifunif
+        integer(4), intent(in) :: nlmin
+        integer(4), intent(in) :: nlmax
+        integer(4), intent(in) :: allow_fmm_short_circuit
+        integer(4), intent(in) :: fmm_min_n
+        integer(4), intent(in) :: fmm_nterms
+        integer(4), intent(in) :: useFMM
+
+        !-------------------- timer and trace modules --------------------------------------
+        character*256,intent(in) :: timer_log_file, trace_log_file, log_dir
+        integer, intent(in) :: window_enabled, trace_enabled, flush_each
+        real(8), intent(in) :: window_interval
+        integer, intent(in) :: trace_verbose
+        !-----------------------------------------------------------------------------------
+
+        logical :: window_enabled_l, trace_enabled_l, flush_each_l
+        logical :: use_fmm
+        integer,dimension(3) :: exchPBC_l
+
+#if USE_MICROMAG
+        type(MicroMagProblem) :: problem
+        type(MicroMagSolution) :: solution
+
+
+
+        !---------------------- initiaize auxiliary modules -----------------------------
+        call auxInit%initAux(log_dir, timer_log_file, trace_log_file, window_enabled, &
+            window_interval, trace_enabled, flush_each, trace_verbose)
+        !---------------------------------------------------------------------------------
+
+
+
+
+        exchPBC_l = merge(.true., .false., exchPBC /= 0)
+        use_fmm = merge(.true., .false., useFMM /= 0)
+        call loadMicroMagProblem( ntot, grid_n, grid_L, grid_type, u_ea, ProblemMode, solver, A0, Ms, K0, &
+            gamma, alpha_mm, temperature, MaxT0, nt_Hext, Hext, nt, t, m0, dem_thres, useCuda, dem_appr, N_ret, N_file_out, &
+            N_load, N_file_in, setTimeDis, nt_alpha, alphat, tol, thres, useCVODE, nt_conv, t_conv, &
+            conv_tol, grid_pts, grid_ele, grid_nod, grid_nnod, exch_nval, exch_nrow, exch_val, exch_rows, &
+            exch_cols, grid_abc, usePrecision, nThreadsMatlab, N_ave, &
+            CV, useReturnHall, useAvgN, demigstp, exch_weigh, exch_meth, exch_intpn, &
+            n_macro, shiftVec, macroShape, sampleShape, exchPBC_l, &
+            passExch, exch_ncols, CrysAxis, K0_arr, K1, K2, problem, dummy_run, fmm_cells_per_node, eps_fmm, ifunif, nlmin, nlmax, allow_fmm_short_circuit, fmm_min_n, fmm_nterms, use_fmm, &
+            useDemag)
+
+        problem%adaptiveHext = .true.
+        problem%maxHextSteps = maxHextSteps
+        problem%nHextAccepted = 0
+        problem%H_start = H_start
+        problem%H_end = H_end
+        problem%dH_initial = dH_initial
+        problem%dH_min = dH_min
+        problem%dH_max = dH_max
+        problem%dH_grow = dH_grow
+        problem%dH_shrink = dH_shrink
+        problem%dM_min = dM_min
+        problem%dM_target = dM_target
+        problem%dM_reject = dM_reject
+        problem%switch_refine_dH = switch_refine_dH
+        problem%use_switch_refine = (use_switch_refine /= 0)
+
+        call SolveLandauLifshitzEquation( problem, solution )
+
+
+        t_out = solution%t_out
+        M_mm = solution%M_out
+        pts = solution%pts
+        H_exc = solution%H_exc
+        H_ext = solution%H_ext
+        H_dem = solution%H_dem
+        H_ani = solution%H_ani
+        n_Hext_accepted = problem%nHextAccepted
+				n_tot_Exch = solution%gridinfo%Exch_mat_ntot
+
+		if (exch_presize*ntot < n_tot_Exch) then
+            write(*,*) 'ExchMat_presize is too small to copy all exchange matrix values. It is set to ', exch_presize*ntot, ' but the exchange matrix has ', n_tot_Exch, ' entries.'
+            write(*,*) 'Please increase the value of exch_presize to at least ', n_tot_Exch/ntot, ' in the Python script.'
+            write(*,*) 'Returning zeros for exchange matrix.'
+            ExchMat_r = 0
+            ExchMat_c = 0
+            ExchMat_v = 0.
+        else
+            ExchMat_r(1:n_tot_Exch) = solution%gridinfo%Exch_mat_r
+            ExchMat_c(1:n_tot_Exch) = solution%gridinfo%Exch_mat_c
+            ExchMat_v(1:n_tot_Exch) = solution%gridinfo%Exch_mat_v
+        end if
+
+        ExchMat_nr = solution%gridinfo%Exch_mat_nr
+		ExchMat_nc = solution%gridinfo%Exch_mat_nc
+#else
+        write(*,*) 'Compiled without micromagnetic part. Returning zeros.'
+        n_tot_Exch = 0
+        ExchMat_r = 0
+        ExchMat_c = 0
+        ExchMat_v = 0.
+        ExchMat_nr = 0
+        ExchMat_nc = 0
+
+        t_out = 0.
+        M_mm(:,:,:,:) = 0.
+        pts(:,:) = 0.
+        H_exc(:,:,:,:) = 0.
+        H_ext(:,:,:,:) = 0.
+        H_dem(:,:,:,:) = 0.
+        H_ani(:,:,:,:) = 0.
+        n_Hext_accepted = 0
+#endif
+
+
+    !---------------------- finalize auxiliary modules -----------------------------
+    call trace%finalize()
+    call timer%log_finalize()
+    !---------------------------------------------------------------------------------
+
+    end subroutine RunMicroMagAdaptiveHysteresis
+
 
 
 

--- a/python/experiments/single_grain/single_grain_coercivity.py
+++ b/python/experiments/single_grain/single_grain_coercivity.py
@@ -209,6 +209,11 @@ def run_single_grain_coercivity(
     allow_fmm_short_circuit: int = 0,
     fmm_min_n: int = 20000,
     fmm_nterms: int = -1,
+    adaptive: bool = False,
+    adaptive_max_steps: int | None = None,
+    adaptive_dh_initial_t: float | None = None,
+    adaptive_dh_min_t: float | None = None,
+    adaptive_dh_max_t: float | None = None,
 ) -> None:
     """Run one size/resolution hysteresis curve and save compatible arrays."""
     steps_t = np.arange(field_max_t, field_min_t + 0.5 * field_step_t, field_step_t)
@@ -245,13 +250,49 @@ def run_single_grain_coercivity(
     print(f"  use_fmm = {use_fmm}")
     print(f"  cuda = {cuda}")
     print(f"  cvode = {cvode}")
+    print(f"  adaptive = {adaptive}")
 
     start_time = time.time()
-    res = problem.run_hysteresis(H_ext=H_ext)
+    if adaptive:
+        max_steps = (
+            adaptive_max_steps if adaptive_max_steps is not None else len(steps_t)
+        )
+        dH_initial_t = (
+            adaptive_dh_initial_t
+            if adaptive_dh_initial_t is not None
+            else field_step_t
+        )
+        dH_min_t = (
+            adaptive_dh_min_t
+            if adaptive_dh_min_t is not None
+            else field_step_t / 10.0
+        )
+        dH_max_t = (
+            adaptive_dh_max_t
+            if adaptive_dh_max_t is not None
+            else field_step_t * 2.0
+        )
+        dH_initial = abs(dH_initial_t) / MU0
+        dH_min = abs(dH_min_t) / MU0
+        dH_max = abs(dH_max_t) / MU0
+        res = problem.run_hysteresis_adaptive(
+            H_start=H_ext[0, 1:4],
+            H_end=H_ext[-1, 1:4],
+            dH_initial=dH_initial,
+            dH_min=dH_min,
+            dH_max=dH_max,
+            max_steps=max_steps,
+            switch_refine_dH=dH_min,
+        )
+        n_fields = res[-1]
+        H_A_per_m = res[4][0, 0, :n_fields, 2]
+    else:
+        res = problem.run_hysteresis(H_ext=H_ext)
+        n_fields = len(steps_t)
+        H_A_per_m = H_ext[:, 3]
     runtime = time.time() - start_time
 
-    Mx, My, Mz = extract_mean_magnetisation(res, len(steps_t), DEFAULT_MS)
-    H_A_per_m = H_ext[:, 3]
+    Mx, My, Mz = extract_mean_magnetisation(res, n_fields, DEFAULT_MS)
     H_T = MU0 * H_A_per_m
     Hc_A_per_m = interpolated_coercivity(H_A_per_m, Mz)
     Hc_T = MU0 * Hc_A_per_m if np.isfinite(Hc_A_per_m) else np.nan
@@ -370,6 +411,15 @@ def main() -> None:
     parser.add_argument("--allow-fmm-short-circuit", type=int, default=0)
     parser.add_argument("--fmm-min-n", type=int, default=20000)
     parser.add_argument("--fmm-nterms", type=int, default=-1)
+    parser.add_argument(
+        "--adaptive",
+        action="store_true",
+        help="Use adaptive backend hysteresis stepping.",
+    )
+    parser.add_argument("--adaptive-max-steps", type=int, default=None)
+    parser.add_argument("--adaptive-dh-initial-t", type=float, default=None)
+    parser.add_argument("--adaptive-dh-min-t", type=float, default=None)
+    parser.add_argument("--adaptive-dh-max-t", type=float, default=None)
     args = parser.parse_args()
 
     if args.size_factor is None:
@@ -403,6 +453,11 @@ def main() -> None:
         allow_fmm_short_circuit=args.allow_fmm_short_circuit,
         fmm_min_n=args.fmm_min_n,
         fmm_nterms=args.fmm_nterms,
+        adaptive=args.adaptive,
+        adaptive_max_steps=args.adaptive_max_steps,
+        adaptive_dh_initial_t=args.adaptive_dh_initial_t,
+        adaptive_dh_min_t=args.adaptive_dh_min_t,
+        adaptive_dh_max_t=args.adaptive_dh_max_t,
     )
 
 

--- a/python/src/magtense/micromag.py
+++ b/python/src/magtense/micromag.py
@@ -961,3 +961,174 @@ class MicromagProblem:
         result[10] = result[10][:n_tot_Exch]  # ExchMat_v
 
         return result
+
+    def run_hysteresis_adaptive(
+            self,
+            H_start: np.ndarray,
+            H_end: np.ndarray,
+            dH_initial: float,
+            dH_min: float,
+            dH_max: float,
+            max_steps: int,
+            dM_min: float = 1e-3,
+            dM_target: float = 1e-2,
+            dM_reject: float = 5e-2,
+            dH_grow: float = 1.25,
+            dH_shrink: float = 0.5,
+            switch_refine_dH: float | None = None,
+    ) -> list[np.ndarray | int]:
+        """
+        Run a micromagnetic hysteresis simulation with adaptive external-field steps.
+
+        The adaptive accept/reject loop is executed by the Fortran backend in a
+        single call. Output arrays are preallocated to ``max_steps`` in Fortran
+        and sliced here to include only accepted field steps.
+        """
+
+        if self.solver != 1:
+            raise ValueError("Adaptive hysteresis requires the explicit solver")
+
+        H_start = np.asarray(H_start, dtype=np.float64)
+        H_end = np.asarray(H_end, dtype=np.float64)
+        if H_start.shape != (3,) or H_end.shape != (3,):
+            raise ValueError("H_start and H_end must be 3-vectors")
+        if max_steps <= 0:
+            raise ValueError("max_steps must be positive")
+        if dH_initial <= 0 or dH_min <= 0 or dH_max <= 0:
+            raise ValueError("dH_initial, dH_min and dH_max must be positive")
+        if dH_min > dH_max:
+            raise ValueError("dH_min must be smaller than or equal to dH_max")
+        if np.allclose(H_start, H_end, rtol=0.0, atol=0.0):
+            raise ValueError("H_start and H_end must differ")
+        if dH_grow <= 1.0:
+            raise ValueError("dH_grow must be larger than 1")
+        if not (0.0 < dH_shrink < 1.0):
+            raise ValueError("dH_shrink must be between 0 and 1")
+
+        nt_h_ext = int(max_steps)
+        nt_h_ext_out = int(max_steps)
+        n_h_ext = int(max_steps)
+        use_switch_refine = switch_refine_dH is not None
+        switch_refine_value = float(switch_refine_dH) if use_switch_refine else 0.0
+        if use_switch_refine and switch_refine_value <= 0:
+            raise ValueError("switch_refine_dH must be positive when provided")
+
+        h_ext = np.zeros(shape=(nt_h_ext, 4), dtype=np.float64, order="F")
+        h_ext[:, 1:4] = H_start
+
+        result = magtensesource.fortrantopythonio.runmicromagadaptivehysteresis(
+            ntot=self.ntot,
+            grid_type=self.grid_type,
+            grid_n=self.grid_n,
+            grid_l=self.grid_L,
+            u_ea=self.u_ea,
+            problemmode=self.prob_mode,
+            solver=self.solver,
+            a0=self.A0,
+            ms=self.Ms,
+            k0=self.K0,
+            k1=self.K1,
+            k2=self.K2,
+            k0_arr=self.K0_arr,
+            crysaxis=self.CrysAxis,
+            gamma=self.gamma,
+            alpha_mm=self.alpha_mm,
+            temperature=self.T,
+            n_hext=n_h_ext,
+            maxt0=self.max_T0,
+            nt_hext=nt_h_ext,
+            nt_hext_out=nt_h_ext_out,
+            hext=h_ext,
+            nt=self.nt,
+            t=self.t,
+            m0=np.concatenate((self.m0[:, 0], self.m0[:, 1], self.m0[:, 2]), axis=None),
+            dem_thres=self.dem_thres,
+            usecuda=self.cuda,
+            dem_appr=self.dem_appr,
+            n_ret=self.N_ret,
+            n_file_out=self.N_file_out,
+            n_load=self.N_load,
+            n_file_in=self.N_file_in,
+            settimedis=self.setTimeDis,
+            nt_alpha=self.nt_alpha,
+            alphat=self.alphat,
+            tol=self.tol,
+            thres=self.thres,
+            usecvode=self.cvode,
+            usedemag=self.usedemag,
+            nt_conv=self.nt_conv,
+            t_conv=self.t_conv,
+            conv_tol=self.conv_tol,
+            grid_pts=self.grid_pts,
+            grid_ele=self.grid_ele,
+            grid_nod=self.grid_nod,
+            grid_nnod=self.grid_nnod,
+            exch_nval=self.exch_nval,
+            exch_nrow=self.exch_nrow,
+            exch_val=self.exch_val,
+            exch_rows=self.exch_rows,
+            exch_cols=self.exch_cols,
+            grid_abc=self.grid_abc,
+            useprecision=self.precision,
+            nthreadsmatlab=self.n_threads,
+            n_ave=self.N_ave,
+            cv=self.cv,
+            usereturnhall=self.usereturnhall,
+            useavgn=self.useavgn,
+            demigstp=self.demigstp,
+            exch_weigh=self.exch_weigh,
+            exch_meth=self.exch_meth,
+            exch_intpn=self.exch_intpn,
+            passexch=self.passexch,
+            exch_ncols=self.exch_ncols,
+            exch_presize=self.exch_presize,
+            n_macro=self.n_macro,
+            shiftvec=self.shiftVec,
+            macroshape=self.macroShape,
+            sampleshape=self.sampleShape,
+            exchpbc=self.exchPBC,
+            h_start=H_start,
+            h_end=H_end,
+            dh_initial=float(dH_initial),
+            dh_min=float(dH_min),
+            dh_max=float(dH_max),
+            maxhextsteps=int(max_steps),
+            dm_min=float(dM_min),
+            dm_target=float(dM_target),
+            dm_reject=float(dM_reject),
+            dh_grow=float(dH_grow),
+            dh_shrink=float(dH_shrink),
+            switch_refine_dh=switch_refine_value,
+            use_switch_refine=int(use_switch_refine),
+            dummy_run=self.dummy_run,
+            fmm_cells_per_node=self.fmm_cells_per_node,
+            eps_fmm=self.fmm_eps,
+            ifunif=self.ifunif,
+            nlmin=self.nlmin,
+            nlmax=self.nlmax,
+            allow_fmm_short_circuit=self.allow_fmm_short_circuit,
+            fmm_min_n=self.fmm_min_n,
+            fmm_nterms=self.fmm_nterms,
+            usefmm=self.use_fmm,
+            log_dir=self.log_dir,
+            timer_log_file=self.timer_log_file,
+            trace_log_file=self.trace_log_file,
+            window_enabled=self.window_enabled,
+            window_interval=self.window_interval,
+            trace_enabled=self.trace_enabled,
+            flush_each=self.flush_each,
+            trace_verbose=self.trace_verbose
+        )
+
+        result = list(result)
+        n_accepted = int(result[7])
+        n_tot_Exch = result[8]
+
+        fixed_order_result = result[0:7] + result[8:14] + [n_accepted]
+        for idx in (1, 3, 4, 5, 6):
+            fixed_order_result[idx] = fixed_order_result[idx][:, :, :n_accepted, :]
+        fixed_order_result[8] = fixed_order_result[8][:n_tot_Exch]  # ExchMat_r
+        fixed_order_result[9] = fixed_order_result[9][:n_tot_Exch]  # ExchMat_c
+        fixed_order_result[10] = fixed_order_result[10][:n_tot_Exch]  # ExchMat_v
+
+        return fixed_order_result

--- a/source/MagTenseMicroMag/LandauLifshitzEquationSolver.f90
+++ b/source/MagTenseMicroMag/LandauLifshitzEquationSolver.f90
@@ -60,6 +60,7 @@
     type(MicroMagSolution),intent(inout) :: sol          !> The solution data structure
     type(MicroMagGridInfo) :: gridinfo                   !> The grid information structure
     integer :: ntot,i,j,k,ind,nt,nt_Hext,stat            !> total no. of tiles (Note from F. Durhuus: n_Hext would make more sense than nt_Hext)
+    integer :: n_reject_max
     procedure(dydt_fct), pointer :: fct                  !> Input function pointer for the function to be integrated
     procedure(no_argument_fct), pointer :: fct_thermal   !> Function pointer for the function that updates the stochastic thermal field
     procedure(callback_fct),pointer :: cb_fct            !> Callback function for displaying progress
@@ -235,6 +236,9 @@
     if ( gb_problem%solver .eq. MicroMagSolverExplicit ) then
         !Go through several different applied fields and find the equilibrium solution for each of them
         nt_Hext = size(gb_problem%Hext, 1)          !The no. of applied fields to consider
+        if (gb_problem%adaptiveHext) then
+            nt_Hext = gb_problem%maxHextSteps
+        endif
     else if ( gb_problem%solver .eq. MicroMagSolverDynamic ) then
         !Simply do a time evolution as specified in the problem
         nt_Hext = 1
@@ -294,36 +298,19 @@
     !$omp parallel default(shared)
     !$omp master
         
-      do i=1,nt_Hext
-          !Applied field
-          gb_solution%HextInd = i
-          
-          if (gb_problem%solver .eq. MicroMagSolverExplicit) then               
-              write(prog_str,'(A20, I5.2, A8, I5.2, A6, F6.2, A7)') 'External Field nr.: ', i, ' out of ', nt_Hext, ' i.e. ', real(i)/real(nt_Hext)*100,'% done'
-              call displayGUIMessage( trim(prog_str) )
-          endif
-          
-          ! This is where the LLG is actually integrated (short description by F. Durhuus)
-          ! fct is a pointer to the dmdt_fct function which returns time derivatives of the normalised magnetic moments
-          ! With m0 as initial condition, integrate from t(1) to t(nt) with effective field updated at each time coordinate t, then store result in t_out and M_out.
-          ! t_conv is time coordinates where convergence is tested when computing equilibrium structure (explicit solver rather than dynamic). Also included in t_out.
-          ! When thermal noise is included (includeThermal = .true.) the magnetisation is normalised each timestep to prevent thermal drift
-          call MagTense_ODE( fct, gb_problem%t, gb_problem%m0, gb_solution%t_out, M_out(:,:,i), gb_problem%includeThermal, fct_thermal, cb_fct, &
-                  gb_problem%setTimeDisplay, gb_problem%tol, gb_problem%thres_value, gb_problem%useCVODE, gb_problem%t_conv, gb_problem%conv_tol )
-          
-          !The initial state of the next solution is the previous solution result
-          gb_problem%m0 = M_out(:,nt,i)
-          
-          !Store the solution
-          gb_solution%M_out(:,:,i,1) =  transpose( M_out(1:ntot,:,i) )
-          gb_solution%M_out(:,:,i,2) =  transpose( M_out((ntot+1):2*ntot,:,i) )
-          gb_solution%M_out(:,:,i,3) =  transpose( M_out((2*ntot+1):3*ntot,:,i)  )
- 
-          call StoreHeffComponents ( gb_problem, gb_solution )              
-      enddo
+      if (gb_problem%adaptiveHext) then
+          n_reject_max = max(100, 10 * gb_problem%maxHextSteps)
+          call SolveAdaptiveHextLoop(fct, fct_thermal, cb_fct, M_out, ntot, nt, n_reject_max)
+      else
+          call SolveFixedHextLoop(fct, fct_thermal, cb_fct, M_out, ntot, nt, nt_Hext)
+      endif
 
       !$omp end master
       !$omp end parallel
+
+      if (gb_problem%adaptiveHext) then
+          nt_Hext = gb_problem%nHextAccepted
+      endif
 
       
         !CALL SYSTEM_CLOCK(c2)
@@ -357,6 +344,197 @@
     call trace%end( "SolveLandauLifshitzEquation", itimer=itimer, verbose=1 )
     end subroutine SolveLandauLifshitzEquation
 
+
+    subroutine SolveFixedHextLoop(fct, fct_thermal, cb_fct, M_out, ntot, nt, nt_Hext)
+    procedure(dydt_fct), pointer :: fct
+    procedure(no_argument_fct), pointer :: fct_thermal
+    procedure(callback_fct),pointer :: cb_fct
+    real(DP),dimension(:,:,:),intent(inout) :: M_out
+    integer,intent(in) :: ntot, nt, nt_Hext
+    integer :: i
+    character*(100) :: prog_str
+
+      do i=1,nt_Hext
+          !Applied field
+          gb_solution%HextInd = i
+
+          if (gb_problem%solver .eq. MicroMagSolverExplicit) then
+              write(prog_str,'(A20, I5, A8, I5, A6, F6.2, A7)') 'External Field nr.: ', i, ' out of ', nt_Hext, ' i.e. ', real(i)/real(nt_Hext)*100,'% done'
+              call displayGUIMessage( trim(prog_str) )
+          endif
+
+          ! This is where the LLG is actually integrated (short description by F. Durhuus)
+          ! fct is a pointer to the dmdt_fct function which returns time derivatives of the normalised magnetic moments
+          ! With m0 as initial condition, integrate from t(1) to t(nt) with effective field updated at each time coordinate t, then store result in t_out and M_out.
+          ! t_conv is time coordinates where convergence is tested when computing equilibrium structure (explicit solver rather than dynamic). Also included in t_out.
+          ! When thermal noise is included (includeThermal = .true.) the magnetisation is normalised each timestep to prevent thermal drift
+          call MagTense_ODE( fct, gb_problem%t, gb_problem%m0, gb_solution%t_out, M_out(:,:,i), gb_problem%includeThermal, fct_thermal, cb_fct, &
+                  gb_problem%setTimeDisplay, gb_problem%tol, gb_problem%thres_value, gb_problem%useCVODE, gb_problem%t_conv, gb_problem%conv_tol )
+
+          !The initial state of the next solution is the previous solution result
+          gb_problem%m0 = M_out(:,nt,i)
+
+          !Store the solution
+          gb_solution%M_out(:,:,i,1) =  transpose( M_out(1:ntot,:,i) )
+          gb_solution%M_out(:,:,i,2) =  transpose( M_out((ntot+1):2*ntot,:,i) )
+          gb_solution%M_out(:,:,i,3) =  transpose( M_out((2*ntot+1):3*ntot,:,i)  )
+
+          call StoreHeffComponents ( gb_problem, gb_solution )
+      enddo
+
+      gb_problem%nHextAccepted = nt_Hext
+    end subroutine SolveFixedHextLoop
+
+    subroutine SolveAdaptiveHextLoop(fct, fct_thermal, cb_fct, M_out, ntot, nt, n_reject_max)
+    procedure(dydt_fct), pointer :: fct
+    procedure(no_argument_fct), pointer :: fct_thermal
+    procedure(callback_fct),pointer :: cb_fct
+    real(DP),dimension(:,:,:),intent(inout) :: M_out
+    integer,intent(in) :: ntot, nt, n_reject_max
+    integer :: i_acc, i_trial, n_reject, n_reject_total
+    real(DP) :: H_delta(3), H_dir(3), H_current(3), H_trial(3), H_remaining(3)
+    real(DP) :: H_distance, remaining_distance, dH, dM, m_parallel_before, m_parallel_trial
+    real(DP),dimension(:),allocatable :: m_before, m_accepted, m_trial
+    logical :: reject_step, reached_end
+    character*(160) :: prog_str
+
+      if (gb_problem%maxHextSteps <= 0) then
+          call displayGUIMessage('Adaptive hysteresis requires maxHextSteps > 0')
+          error stop 'Adaptive hysteresis requires maxHextSteps > 0'
+      endif
+      if (gb_problem%dH_initial <= 0.0_DP .or. gb_problem%dH_min <= 0.0_DP .or. gb_problem%dH_max <= 0.0_DP) then
+          call displayGUIMessage('Adaptive hysteresis requires positive dH_initial, dH_min and dH_max')
+          error stop 'Adaptive hysteresis requires positive dH_initial, dH_min and dH_max'
+      endif
+      if (gb_problem%dH_min > gb_problem%dH_max) then
+          call displayGUIMessage('Adaptive hysteresis requires dH_min <= dH_max')
+          error stop 'Adaptive hysteresis requires dH_min <= dH_max'
+      endif
+
+      H_delta = gb_problem%H_end - gb_problem%H_start
+      H_distance = sqrt(sum(H_delta**2))
+      if (H_distance <= tiny(1.0_DP)) then
+          call displayGUIMessage('Adaptive hysteresis requires H_start and H_end to differ')
+          error stop 'Adaptive hysteresis requires H_start and H_end to differ'
+      endif
+
+      H_dir = H_delta / H_distance
+      H_current = gb_problem%H_start
+      dH = min(max(gb_problem%dH_initial, gb_problem%dH_min), gb_problem%dH_max)
+      allocate(m_before(3*ntot), m_accepted(3*ntot), m_trial(3*ntot))
+      m_accepted = gb_problem%m0
+      i_acc = 0
+      n_reject = 0
+      n_reject_total = 0
+      reached_end = .false.
+
+      do while (.not. reached_end .and. i_acc < gb_problem%maxHextSteps)
+          remaining_distance = dot_product(gb_problem%H_end - H_current, H_dir)
+          if (remaining_distance <= max(1.0e-12_DP * H_distance, tiny(1.0_DP))) exit
+
+          i_trial = i_acc + 1
+          H_trial = H_current + min(dH, remaining_distance) * H_dir
+          if (remaining_distance <= dH) H_trial = gb_problem%H_end
+
+          m_before = m_accepted
+          gb_problem%m0 = m_before
+          gb_solution%HextInd = i_trial
+          gb_problem%Hext(i_trial,1) = 0.0_DP
+          gb_problem%Hext(i_trial,2:4) = H_trial
+
+          write(prog_str,'(A31, I5, A8, I5, A6, F6.2, A7)') 'Adaptive External Field nr.: ', i_trial, ' max ', gb_problem%maxHextSteps, ' i.e. ', real(i_trial)/real(gb_problem%maxHextSteps)*100,'% done'
+          call displayGUIMessage( trim(prog_str) )
+
+          call MagTense_ODE( fct, gb_problem%t, gb_problem%m0, gb_solution%t_out, M_out(:,:,i_trial), gb_problem%includeThermal, fct_thermal, cb_fct, &
+                  gb_problem%setTimeDisplay, gb_problem%tol, gb_problem%thres_value, gb_problem%useCVODE, gb_problem%t_conv, gb_problem%conv_tol )
+
+          m_trial = M_out(:,nt,i_trial)
+          dM = adaptiveStepMetric(m_before, m_trial, ntot)
+
+          m_parallel_before = meanMagnetisationAlongField(m_before, ntot, H_dir)
+          m_parallel_trial = meanMagnetisationAlongField(m_trial, ntot, H_dir)
+          reject_step = .false.
+          if (dM > gb_problem%dM_reject .and. dH > gb_problem%dH_min) reject_step = .true.
+          if (gb_problem%use_switch_refine) then
+              if (m_parallel_before * m_parallel_trial < 0.0_DP .and. dH > gb_problem%switch_refine_dH .and. dH > gb_problem%dH_min) reject_step = .true.
+          endif
+
+          if (reject_step) then
+              if (n_reject > 0 .and. dH <= gb_problem%dH_min) then
+                  reject_step = .false.
+              else
+                  dH = max(dH * gb_problem%dH_shrink, gb_problem%dH_min)
+              endif
+          endif
+
+          if (reject_step) then
+              gb_problem%m0 = m_before
+              n_reject = n_reject + 1
+              n_reject_total = n_reject_total + 1
+              if (n_reject_total > n_reject_max) then
+                  call displayGUIMessage('Adaptive hysteresis stopped after too many rejected field steps')
+                  error stop 'Adaptive hysteresis stopped after too many rejected field steps'
+              endif
+              cycle
+          endif
+
+          if (dM > gb_problem%dM_reject .and. dH <= gb_problem%dH_min) then
+              call displayGUIMessage('Adaptive hysteresis accepting a large magnetisation change at dH_min')
+          endif
+
+          i_acc = i_acc + 1
+          n_reject = 0
+          H_current = H_trial
+          m_accepted = m_trial
+          gb_problem%m0 = m_accepted
+          gb_solution%HextInd = i_acc
+          gb_problem%Hext(i_acc,1) = 0.0_DP
+          gb_problem%Hext(i_acc,2:4) = H_current
+
+          gb_solution%M_out(:,:,i_acc,1) =  transpose( M_out(1:ntot,:,i_trial) )
+          gb_solution%M_out(:,:,i_acc,2) =  transpose( M_out((ntot+1):2*ntot,:,i_trial) )
+          gb_solution%M_out(:,:,i_acc,3) =  transpose( M_out((2*ntot+1):3*ntot,:,i_trial)  )
+
+          call StoreHeffComponents ( gb_problem, gb_solution )
+
+          H_remaining = gb_problem%H_end - H_current
+          reached_end = sqrt(sum(H_remaining**2)) <= max(1.0e-10_DP * H_distance, 1.0e-9_DP)
+
+          if (dM < gb_problem%dM_min) then
+              dH = min(dH * gb_problem%dH_grow, gb_problem%dH_max)
+          else if (dM > gb_problem%dM_target) then
+              dH = max(dH * gb_problem%dH_shrink, gb_problem%dH_min)
+          endif
+      enddo
+
+      gb_problem%nHextAccepted = i_acc
+      if (.not. reached_end) then
+          call displayGUIMessage('Adaptive hysteresis reached maxHextSteps before H_end')
+      endif
+      deallocate(m_before, m_accepted, m_trial)
+    end subroutine SolveAdaptiveHextLoop
+
+    real(DP) function adaptiveStepMetric(m_before, m_trial, ntot) result(dM_rms)
+    real(DP),dimension(:),intent(in) :: m_before, m_trial
+    integer,intent(in) :: ntot
+    integer :: j
+      dM_rms = 0.0_DP
+      do j = 1, 3*ntot
+          dM_rms = dM_rms + (m_trial(j) - m_before(j))**2
+      enddo
+      dM_rms = sqrt(dM_rms / real(ntot, DP))
+    end function adaptiveStepMetric
+
+    real(DP) function meanMagnetisationAlongField(m, ntot, H_dir) result(M_parallel)
+    real(DP),dimension(:),intent(in) :: m
+    integer,intent(in) :: ntot
+    real(DP),dimension(3),intent(in) :: H_dir
+    real(DP) :: M_mean(3)
+      M_mean(1) = sum(m(1:ntot)) / real(ntot, DP)
+      M_mean(2) = sum(m(ntot+1:2*ntot)) / real(ntot, DP)
+      M_mean(3) = sum(m(2*ntot+1:3*ntot)) / real(ntot, DP)
+      M_parallel = dot_product(M_mean, H_dir)
+    end function meanMagnetisationAlongField
     !>-----------------------------------------
     !> @author Kaspar K. Nielsen, kasparkn@gmail.com, DTU, 2019
     !> @brief

--- a/source/MagTenseMicroMag/MicroMagParameters.f90
+++ b/source/MagTenseMicroMag/MicroMagParameters.f90
@@ -144,6 +144,21 @@ include "mkl_dfti.f90"
         logical :: includeThermal                         !> Whether thermal noise is included in the simulations
         
         real(DP),dimension(:,:),allocatable :: Hext       !> Applied field as a function of time. Size (nt,3) with the latter dimension specifying the spatial dimensions.
+        logical :: adaptiveHext = .false.                 !> Enable adaptive external-field stepping for explicit hysteresis.
+        integer :: maxHextSteps = 0                       !> Maximum number of accepted adaptive external-field steps.
+        integer :: nHextAccepted = 0                      !> Number of accepted adaptive external-field steps.
+        real(DP),dimension(3) :: H_start = 0.0_DP         !> Adaptive hysteresis start field [A/m].
+        real(DP),dimension(3) :: H_end = 0.0_DP           !> Adaptive hysteresis end field [A/m].
+        real(DP) :: dH_initial = 0.0_DP                   !> Initial adaptive field-step length [A/m].
+        real(DP) :: dH_min = 0.0_DP                       !> Minimum adaptive field-step length [A/m].
+        real(DP) :: dH_max = 0.0_DP                       !> Maximum adaptive field-step length [A/m].
+        real(DP) :: dH_grow = 1.25_DP                     !> Factor for increasing adaptive field-step length.
+        real(DP) :: dH_shrink = 0.5_DP                    !> Factor for decreasing adaptive field-step length.
+        real(DP) :: dM_min = 1.0e-3_DP                    !> Magnetisation-change threshold for growing adaptive field steps.
+        real(DP) :: dM_target = 1.0e-2_DP                 !> Magnetisation-change threshold for shrinking adaptive field steps.
+        real(DP) :: dM_reject = 5.0e-2_DP                 !> Magnetisation-change threshold for rejecting adaptive field steps.
+        real(DP) :: switch_refine_dH = 0.0_DP             !> Maximum accepted step across magnetisation sign changes [A/m].
+        logical :: use_switch_refine = .false.            !> Enable adaptive sign-change refinement.
         real(DP),dimension(:,:),allocatable :: alpha      !> A time dependent damping parameter, i.e. as a function of time. Size (nt,1).
         
         real(DP),dimension(:),allocatable :: t              !> Time array for the desired output times


### PR DESCRIPTION
### Motivation
- Provide an adaptive hysteresis driver that automatically adjusts external-field step sizes to capture magnetisation changes efficiently during explicit hysteresis solves.
- Expose the adaptive hysteresis capability through the Fortran API and the Python `MicromagProblem` wrapper so higher-level scripts can opt into adaptive stepping.
- Add CLI options to the single-grain coercivity experiment to allow easy switching between fixed-step and adaptive hysteresis runs.

### Description
- Introduces a new Fortran entrypoint `RunMicroMagAdaptiveHysteresis` that mirrors the existing API and returns preallocated arrays sliced to the number of accepted adaptive steps.
- Extends `MicroMagProblem` in `MicroMagParameters.f90` with adaptive hysteresis parameters (`adaptiveHext`, `maxHextSteps`, `H_start`, `H_end`, `dH_initial`, `dH_min`, `dH_max`, `dM_*`, `dH_grow`, `dH_shrink`, `switch_refine_dH`, `use_switch_refine`, `nHextAccepted`).
- Reworks the solver in `LandauLifshitzEquationSolver.f90` to split the fixed- and adaptive-loop logic into `SolveFixedHextLoop` and `SolveAdaptiveHextLoop`, and implements the adaptive accept/reject logic, step-size adaptation, and helper metrics (`adaptiveStepMetric`, `meanMagnetisationAlongField`).
- Adds Python bindings and helper `MicromagProblem.run_hysteresis_adaptive` in `micromag.py` to call the new Fortran routine and post-process results (slicing output arrays and exposing `n_accepted`), and adapts returned exchange-matrix arrays.
- Adds CLI flags and plumbing in `single_grain_coercivity.py` to enable the adaptive backend and configure adaptive parameters from command line options.

### Testing
- Built the Fortran library and imported the Python package to ensure the new Fortran routines are linkable and the Python bindings load. 
- Performed a smoke test by invoking the updated single-grain coercivity flow with the adaptive backend enabled to confirm the new API path executes without immediate errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2678d240448326b9179c7e336ad64e)